### PR TITLE
feat: add secure Supabase client support

### DIFF
--- a/apps/demo-app/package.json
+++ b/apps/demo-app/package.json
@@ -10,9 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "supafile-react-upload-widget": "workspace:*",
+    "@supabase/supabase-js": "^2.57.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "supafile-react-upload-widget": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/apps/demo-app/src/App.tsx
+++ b/apps/demo-app/src/App.tsx
@@ -1,23 +1,25 @@
 import { FileUploader, type UploadedFile } from 'supafile-react-upload-widget';
+import { createClient } from '@supabase/supabase-js';
 
+// Initialize Supabase client (recommended approach)
+const supabase = createClient(
+  'https://your-project.supabase.co',
+  'your-supabase-anon-key'
+);
 
 const App = () => (
-
-
   <div className='w-full h-full flex flex-col justify-center items-center'>
     <h1 className='text-2xl font-bold'>Supafile Demo</h1>
-    < FileUploader
-      supabaseUrl="https://your-project.supabase.co"
-      supabaseAnonKey="your-supabase-anon-key"
+    <FileUploader
+      supabase={supabase}
       bucket="uploads"
       maxFileSize={10 * 1024 * 1024}
       allowedTypes={['image/png', 'image/jpeg', 'application/pdf']}
       onUploadComplete={(file: UploadedFile) => console.log('Uploaded file', file)}
-      onUploadError={(file, err) => console.error('Upload error', file.name, err)}
+      onUploadError={(file: File, err: Error) => console.error('Upload error', file.name, err)}
       showFilePreviews={true}
     />
   </div>
-
 );
 
 export default App;

--- a/packages/upload-widget/README.md
+++ b/packages/upload-widget/README.md
@@ -27,7 +27,32 @@ pnpm add supafile-react-upload-widget
 
 ## Quick Start
 
-Perfect for Supabase projects! Just provide your Supabase credentials and you're ready to go:
+Perfect for Supabase projects! Two ways to use the component:
+
+### Option 1: Pass Supabase Client (Recommended for Production)
+
+```tsx
+import { FileUploader } from 'supafile-react-upload-widget';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  'https://your-project.supabase.co',
+  'your-supabase-anon-key'
+);
+
+function App() {
+  return (
+    <FileUploader
+      supabase={supabase}
+      bucket="your-storage-bucket"
+      onUploadComplete={(file) => console.log('File uploaded to Supabase:', file)}
+      onUploadError={(file, error) => console.error('Upload failed:', error)}
+    />
+  );
+}
+```
+
+### Option 2: Pass Credentials Directly (For Demos/Testing Only)
 
 ```tsx
 import { FileUploader } from 'supafile-react-upload-widget';
@@ -45,6 +70,8 @@ function App() {
 }
 ```
 
+> **⚠️ Security Note**: Option 2 exposes your Supabase credentials in the frontend code. Use Option 1 (passing a Supabase client) for production applications.
+
 ### Supabase Setup
 
 1. Create a Supabase project at [supabase.com](https://supabase.com)
@@ -58,9 +85,12 @@ function App() {
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `supabaseUrl` | `string` | Your Supabase project URL (e.g., `https://xyz.supabase.co`) |
-| `supabaseAnonKey` | `string` | Your Supabase anonymous/public key |
+| `supabase` | `SupabaseClient` | **Option 1**: Your Supabase client instance (recommended for production) |
+| `supabaseUrl` | `string` | **Option 2**: Your Supabase project URL (for demos/testing only) |
+| `supabaseAnonKey` | `string` | **Option 2**: Your Supabase anonymous/public key (for demos/testing only) |
 | `bucket` | `string` | Supabase Storage bucket name |
+
+> **Note**: You must provide either `supabase` OR both `supabaseUrl` + `supabaseAnonKey`. The `supabase` prop is recommended for production use.
 
 ### Optional Props
 

--- a/packages/upload-widget/src/components/FileUploader.tsx
+++ b/packages/upload-widget/src/components/FileUploader.tsx
@@ -2,10 +2,14 @@ import React, { useRef } from 'react';
 import { useUpload, type UploadedFile } from '../hooks/useUpload';
 import { FilePreview } from './FilePreview';
 import { Upload, X } from 'lucide-react';
+import { SupabaseClient } from '@supabase/supabase-js';
 
 interface FileUploaderProps {
-    supabaseUrl: string;
-    supabaseAnonKey: string;
+    // Option 1: Pass Supabase client (recommended for production)
+    supabase?: SupabaseClient;
+    // Option 2: Pass credentials directly (for demos/testing only)
+    supabaseUrl?: string;
+    supabaseAnonKey?: string;
     bucket: string;
     maxFileSize?: number;
     allowedTypes?: string[];
@@ -36,6 +40,7 @@ interface FileUploaderProps {
 }
 
 export const FileUploader: React.FC<FileUploaderProps> = ({
+    supabase,
     supabaseUrl,
     supabaseAnonKey,
     bucket,
@@ -67,7 +72,18 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
     buttonSize
 }) => {
     const inputRef = useRef<HTMLInputElement>(null);
-    const { files, uploading, uploadFiles, removeFile } = useUpload({ supabaseUrl, supabaseAnonKey, bucket });
+
+    // Validate that either supabase client or credentials are provided
+    if (!supabase && (!supabaseUrl || !supabaseAnonKey)) {
+        throw new Error('Either supabase client or supabaseUrl + supabaseAnonKey must be provided');
+    }
+
+    const { files, uploading, uploadFiles, removeFile } = useUpload({
+        supabase,
+        supabaseUrl,
+        supabaseAnonKey,
+        bucket
+    });
 
     const handleFiles = (selectedFiles: FileList | null) => {
         if (!selectedFiles) return;

--- a/packages/upload-widget/src/hooks/useUpload.ts
+++ b/packages/upload-widget/src/hooks/useUpload.ts
@@ -14,21 +14,26 @@ export interface UploadError {
 }
 
 interface UploadOptions {
-    supabaseUrl: string;
-    supabaseAnonKey: string;
+    // Option 1: Pass Supabase client (recommended for production)
+    supabase?: SupabaseClient;
+    // Option 2: Pass credentials directly (for demos/testing only)
+    supabaseUrl?: string;
+    supabaseAnonKey?: string;
     bucket: string;
     maxFileSize?: number; // in bytes
     allowedTypes?: string[];
 }
 
 export const useUpload = ({
+    supabase,
     supabaseUrl,
     supabaseAnonKey,
     bucket,
     maxFileSize = 10 * 1024 * 1024, // 10MB default
     allowedTypes = [] // empty array means all types allowed
 }: UploadOptions) => {
-    const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+    // Use provided client or create one from credentials
+    const client: SupabaseClient = supabase || createClient(supabaseUrl!, supabaseAnonKey!);
     const [files, setFiles] = useState<UploadedFile[]>([]);
     const [uploading, setUploading] = useState(false);
     const [errors, setErrors] = useState<UploadError[]>([]);
@@ -68,7 +73,7 @@ export const useUpload = ({
                 // Simulate progress for now (Supabase doesn't provide real progress)
                 onProgress?.(file, 0);
 
-                const { data, error } = await supabase.storage
+                const { data, error } = await client.storage
                     .from(bucket)
                     .upload(fileName, file);
 
@@ -78,7 +83,7 @@ export const useUpload = ({
                 }
 
                 // Use the new getPublicUrl method
-                const { data: { publicUrl } } = supabase.storage
+                const { data: { publicUrl } } = client.storage
                     .from(bucket)
                     .getPublicUrl(fileName);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   apps/demo-app:
     dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.57.0
+        version: 2.57.0
       react:
         specifier: ^19.1.1
         version: 19.1.1


### PR DESCRIPTION
Add support for passing Supabase client instance (recommended for production) Keep backward compatibility with direct credentials (for demos/testing) Add validation to ensure either client or credentials are provided Update TypeScript declarations and documentation
Add security warnings for credential-based usage
Update demo app to use secure client approach